### PR TITLE
Correct exit status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "eipv"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eipv"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["lightclient <crates@garnett.dev>"]
 license = "MIT OR Apache-2.0"
 description = "Ethereum Improvement Proposal validator"

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod validators;
 
 use clap::{App, Arg};
 use runner::Runner;
+use std::process::exit;
 
 fn main() {
     let matches = App::new("eipv")
@@ -44,9 +45,14 @@ fn main() {
         Ok(mut r) => {
             r.validate();
             println!("{}", r);
+
+            if r.invalid() != 0 {
+                exit(1)
+            }
         }
         Err(e) => {
             println!("{}", e);
+            exit(1)
         }
     }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -58,6 +58,10 @@ impl<'a> Runner<'a> {
         Ok(ret)
     }
 
+    pub fn invalid(&self) -> u64 {
+        self.invalid
+    }
+
     pub fn validate(&mut self) {
         match fs::metadata(self.path) {
             Ok(m) => {


### PR DESCRIPTION
`exit(0)` if none are invalid, `exit(1)` otherwise.