### PR TITLE
Update Clap to beta 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,9 +64,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.0.0-beta.1"
+version = "3.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "860643c53f980f0d38a5e25dfab6c3c93b2cb3aa1fe192643d17a293c6c41936"
+checksum = "4bd1061998a501ee7d4b6d449020df3266ca3124b941ec56cf2005c3779ca142"
 dependencies = [
  "atty",
  "bitflags",
@@ -83,9 +83,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.0.0-beta.1"
+version = "3.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb51c9e75b94452505acd21d929323f5a5c6c4735a852adbd39ef5fb1b014f30"
+checksum = "370f715b81112975b1b69db93e0b56ea4cd4e5002ac43b2da8474106a54096a1"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -258,9 +258,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error"
-version = "0.4.12"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18f33027081eba0a6d8aba6d1b1c3a3be58cbb12106341c2d5759fcd9b5277e7"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
@@ -271,14 +271,12 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error-attr"
-version = "0.4.12"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a5b4b77fdb63c1eca72173d68d24501c54ab1269409f6b672c85deb18af69de"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
- "syn-mid",
  "version_check",
 ]
 
@@ -336,17 +334,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn-mid"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "termcolor"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,9 +344,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+checksum = "203008d98caf094106cfaba70acfed15e18ed3ddb7d94e49baec153a2b462789"
 dependencies = [
  "unicode-width",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-clap = "3.0.0-beta.2"
+clap = "=3.0.0-beta.2"
 chrono = "0.4"
 regex = "1.3"
 url = "2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-clap = "3.0.0-beta.1"
+clap = "3.0.0-beta.2"
 chrono = "0.4"
 regex = "1.3"
 url = "2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eipv"
-version = "0.0.5"
+version = "0.0.6"
 authors = ["lightclient <crates@garnett.dev>"]
 license = "MIT OR Apache-2.0"
 description = "Ethereum Improvement Proposal validator"

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,20 +14,20 @@ fn main() {
         .version("0.0.0")
         .about("Validate the structure of Ethereum Improvement Proposals")
         .arg(
-            Arg::with_name("path")
+            Arg::new("path")
                 .takes_value(true)
                 .required(true)
                 .about("Directory of EIPs or path to a specific EIP"),
         )
         .arg(
-            Arg::with_name("ignore")
+            Arg::new("ignore")
                 .takes_value(true)
                 .short('i')
                 .long("ignore")
                 .about("Run the validation suite, ignoring the specified errors."),
         )
         .arg(
-            Arg::with_name("skip")
+            Arg::new("skip")
                 .takes_value(true)
                 .short('s')
                 .long("skip")


### PR DESCRIPTION
There was a breakage on the EIPs that caused `eipv` to fail to compile. The cause was that Cargo will happily replace a package dependency with the latest beta, [unless specified differently](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#inequality-requirements). I've fixed the code to use beta 2 and updated the dependency requirement to used *exactly` beta 2.