### PR TITLE
Update workflows to run on push, pr, and dispatch

### DIFF
--- a/.github/workflows/eipv-test.yaml
+++ b/.github/workflows/eipv-test.yaml
@@ -1,4 +1,4 @@
-on: [push]
+on: [push, pull_request, workflow_dispatch]
 
 name: ci
 


### PR DESCRIPTION
Looks like the workflow isn't running for #28 -- I'm wondering if because `push` means only a push to this repository and not a fork contribution.